### PR TITLE
introduce IEx.pry

### DIFF
--- a/test/iex_debug_test.exs
+++ b/test/iex_debug_test.exs
@@ -3,6 +3,7 @@ defmodule IexDebugTest do
   doctest IexDebug
 
   test "greets the world" do
+    require IEx; IEx.pry()
     assert IexDebug.hello() == :world
   end
 end


### PR DESCRIPTION
`require IEx; IEx.pry()` is no longer working with `iex -S mix test` as it used to

<img width="908" alt="image" src="https://github.com/user-attachments/assets/6dd99b88-5955-4aea-b4a2-2017f69faf92" />
